### PR TITLE
ci: add CI build

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,56 @@
+# Copyright (c) 2024, Pecunia Project. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; version 2 of the
+# License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+name: Build Pecunia
+
+inputs:
+  version:
+    description: The version to be built.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Without a Developer ID, we cannot access the keychain. Remove the
+    # entitlement to avoid signing.
+    - name: Remove Keychain entitlement
+      run: plutil -remove keychain-access-groups Pecunia.entitlements
+      shell: sh
+
+    - name: Build the app
+      env:
+        MARKETING_VERSION: ${{ inputs.version }}
+      run: |
+        xcodebuild \
+            -configuration Deployment \
+            -scheme Pecunia \
+            -workspace Pecunia.xcworkspace \
+            CODE_SIGN_IDENTITY=- \
+            MARKETING_VERSION="$MARKETING_VERSION" \
+            SYMROOT="$PWD/Build/Products"
+      shell: sh
+
+    # Uploading the files directly doesn't produce a working app. Create
+    # a .tar first.
+    - name: Package the app
+      run: |
+        pax \
+            -f Pecunia.tar \
+            -s :Build/Products/Deployment/:: \
+            -w \
+            Build/Products/Deployment/Pecunia.app
+      shell: sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2024, Pecunia Project. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; version 2 of the
+# License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+name: Build Pecunia
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Determine version
+        run: |
+          describe=$(git describe --tags)
+          printf 'MARKETING_VERSION=%s\n' "${describe#Release-}" >>$GITHUB_ENV
+
+      # Without a Developer ID, we cannot access the keychain. Remove the
+      # entitlement to avoid signing.
+      - name: Remove Keychain entitlement
+        run: plutil -remove keychain-access-groups Pecunia.entitlements
+
+      - name: Build the app
+        run: |
+          xcodebuild \
+              -configuration Deployment \
+              -scheme Pecunia \
+              -workspace Pecunia.xcworkspace \
+              CODE_SIGN_IDENTITY=- \
+              MARKETING_VERSION="$MARKETING_VERSION" \
+              SYMROOT="$PWD/Build/Products"
+
+      # Uploading the files directly doesn't produce a working app. Create
+      # a .tar first.
+      - name: Package the app
+        run: |
+          pax \
+              -f Pecunia.tar \
+              -s :Build/Products/Deployment/:: \
+              -w \
+              Build/Products/Deployment/Pecunia.app
+
+      - id: upload-artifact
+        name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pecunia-${{ env.MARKETING_VERSION }}
+          path: Pecunia.tar
+
+      - name: Add comment on PR
+        env:
+          ARTIFACT_URL: ${{ steps.upload-artifact.outputs.artifact-url }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { ARTIFACT_URL, MARKETING_VERSION } = process.env;
+
+            await github.rest.issues.createComment({
+                ...context.repo,
+                body: `Download [Pecunia-${MARKETING_VERSION}](${ARTIFACT_URL}).`,
+                issue_number: context.issue.number,
+            });

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
-name: Build Pecunia
+name: Verify pull request
 
 on:
   pull_request:
@@ -36,30 +36,10 @@ jobs:
           describe=$(git describe --tags)
           printf 'MARKETING_VERSION=%s\n' "${describe#Release-}" >>$GITHUB_ENV
 
-      # Without a Developer ID, we cannot access the keychain. Remove the
-      # entitlement to avoid signing.
-      - name: Remove Keychain entitlement
-        run: plutil -remove keychain-access-groups Pecunia.entitlements
-
-      - name: Build the app
-        run: |
-          xcodebuild \
-              -configuration Deployment \
-              -scheme Pecunia \
-              -workspace Pecunia.xcworkspace \
-              CODE_SIGN_IDENTITY=- \
-              MARKETING_VERSION="$MARKETING_VERSION" \
-              SYMROOT="$PWD/Build/Products"
-
-      # Uploading the files directly doesn't produce a working app. Create
-      # a .tar first.
-      - name: Package the app
-        run: |
-          pax \
-              -f Pecunia.tar \
-              -s :Build/Products/Deployment/:: \
-              -w \
-              Build/Products/Deployment/Pecunia.app
+      - name: Build Pecunia
+        uses: ./.github/actions/build
+        with:
+          version: ${{ env.MARKETING_VERSION }}
 
       - id: upload-artifact
         name: Upload artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2024, Pecunia Project. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; version 2 of the
+# License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install semantic-release
+        run: npm install --global @semantic-release/exec semantic-release
+
+      - name: Determine version
+        run: semantic-release --dry-run
+
+      - name: Build Pecunia
+        uses: ./.github/actions/build
+        with:
+          version: ${{ env.MARKETING_VERSION }}
+
+      - name: Create release
+        run: semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,26 @@
+{
+    "branches": [
+        "master"
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/exec",
+            {
+                "verifyReleaseCmd": "printf 'MARKETING_VERSION=${nextRelease.version}\n' >>$GITHUB_ENV"
+            },
+            "@semantic-release/github",
+            {
+                "assets": [
+                    {
+                        "label": "Pecunia ${nextRelease.version}",
+                        "name": "Pecunia-${nextRelease.version}",
+                        "path": "Pecunia.tar"
+                    }
+                ]
+            }
+        ]
+    ],
+    "tagFormat": "Release-${version}"
+}


### PR DESCRIPTION
Run a build for every PR. This has a number of advantages:
 - it shows whether the `master` branch can be built,
 - it shows whether PRs can be built,
 - it allows users to test PRs before they have been merged,
 - it serves as documentation-as-code for the build process.